### PR TITLE
fix order of equipments when exporting filters

### DIFF
--- a/src/main/java/org/gridsuite/filter/server/FilterService.java
+++ b/src/main/java/org/gridsuite/filter/server/FilterService.java
@@ -639,7 +639,11 @@ public class FilterService {
     }
 
     public List<FilterEquipments> exportFilters(List<UUID> ids, UUID networkUuid, String variantId) {
-        return getFilters(ids).stream()
+
+        // we stream on the ids so that we can keep the same order of ids sent
+        return ids.stream()
+                .map(id -> getFilter(id).orElse(null))
+                .filter(Objects::nonNull)
                 .map(filter -> filter.getFilterEquipments(getIdentifiableAttributes(filter, networkUuid, variantId)))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/gridsuite/filter/server/dto/IdentifierListFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/IdentifierListFilter.java
@@ -64,7 +64,7 @@ public class IdentifierListFilter extends AbstractFilter {
                         .orElseGet(() -> {
                             notFound.add(f.getEquipmentID());
                             return null;
-                }))
+                        }))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 

--- a/src/main/java/org/gridsuite/filter/server/dto/IdentifierListFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/IdentifierListFilter.java
@@ -15,9 +15,7 @@ import lombok.experimental.SuperBuilder;
 import org.gridsuite.filter.server.utils.EquipmentType;
 import org.gridsuite.filter.server.utils.FilterType;
 
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -57,19 +55,23 @@ public class IdentifierListFilter extends AbstractFilter {
 
     @Override
     public FilterEquipments getFilterEquipments(List<IdentifiableAttributes> identifiableAttributes) {
-        if (filterEquipmentsAttributes.size() != identifiableAttributes.size()) {
-            List<String> equipmentIds = identifiableAttributes.stream().map(IdentifiableAttributes::getId).collect(Collectors.toList());
-            List<String> notFoundEquipments = filterEquipmentsAttributes.stream()
-                    .map(IdentifierListFilterEquipmentAttributes::getEquipmentID)
-                    .filter(equipment -> !equipmentIds.contains(equipment))
-                    .collect(Collectors.toList());
+        // we keep the same order of the equipments in the filter
+        List<String> notFound = new ArrayList<>();
+        List<IdentifiableAttributes> orderedIdentifiableAttributes = filterEquipmentsAttributes.stream()
+                .map(f -> identifiableAttributes.stream()
+                        .filter(attribute -> Objects.equals(attribute.getId(), f.getEquipmentID()))
+                        .findFirst()
+                        .orElseGet(() -> {
+                            notFound.add(f.getEquipmentID());
+                            return null;
+                }))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
 
-            return FilterEquipments.builder()
-                    .filterId(getId())
-                    .identifiableAttributes(identifiableAttributes)
-                    .notFoundEquipments(notFoundEquipments)
-                    .build();
-        }
-        return super.getFilterEquipments(identifiableAttributes);
+        return FilterEquipments.builder()
+                .filterId(getId())
+                .identifiableAttributes(orderedIdentifiableAttributes)
+                .notFoundEquipments(notFound)
+                .build();
     }
 }


### PR DESCRIPTION
The purpose of this modification is to keep the same order of filters, and equipment in manual filter, as the order chosen by the user.
The order is important in generator scaling when using stacking up as variation mode