### PR TITLE
Fix Liquibase `diff` when JPA entities not modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 /target/
 /.idea/
 /*.iml
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/main/resources/db/changelog/changesets/changelog_20230810T095237Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20230810T095237Z.xml
@@ -3,7 +3,7 @@
     <changeSet author="hedhiliabd" id="1626975171877-1">
         <validCheckSum>8:69b54d23810d9c683a83059dd23bd9a0</validCheckSum>
         <modifyDataType columnName="equipment_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="identifier_list_filter"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/application-default.yaml
+++ b/src/test/resources/application-default.yaml
@@ -5,7 +5,7 @@ spring:
       dialect: org.hibernate.dialect.H2Dialect
       hibernate.format_sql: true
     hibernate:
-      #to turn off schema validation that fails (because of clob types) and blocks tests even if the the schema is compatible
+      #to turn off schema validation that fails (because of clob types) and blocks tests even if the schema is compatible
       ddl-auto: none
 logging:
   level:
@@ -17,5 +17,5 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"


### PR DESCRIPTION
Liquibase `diff` generate changes when using `main` branch without modifying JPA entities.  
* The diff come from recent migrations updating some rules in Liquibase.
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54