### PR TITLE
Refactor line and transformer filter entities to avoid code duplication

### DIFF
--- a/src/main/java/org/gridsuite/filter/server/dto/AbstractLineFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/AbstractLineFilter.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.filter.server.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.springframework.util.CollectionUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+@Schema(description = "Line Filters", allOf = CriteriaFilter.class)
+public abstract class AbstractLineFilter extends AbstractEquipmentFilterForm {
+
+    @Schema(description = "SubstationName1")
+    String substationName1;
+
+    @Schema(description = "SubstationName2")
+    String substationName2;
+
+    @Schema(description = "Countries1")
+    private SortedSet<String> countries1;
+
+    @Schema(description = "Countries2")
+    private SortedSet<String> countries2;
+
+    @Schema(description = "Free properties 1")
+    // LinkedHashMap to keep order too
+    @JsonDeserialize(as = LinkedHashMap.class)
+    private Map<String, List<String>> freeProperties1;
+
+    @Schema(description = "Free properties 2")
+    // LinkedHashMap to keep order too
+    @JsonDeserialize(as = LinkedHashMap.class)
+    private Map<String, List<String>> freeProperties2;
+
+    AbstractLineFilter(String equipmentID, String equipmentName, String substationName1, String substationName2, SortedSet<String> countries1, SortedSet<String> countries2) {
+        super(equipmentID, equipmentName);
+        this.substationName1 = substationName1;
+        this.substationName2 = substationName2;
+        this.countries1 = countries1;
+        this.countries2 = countries2;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty()
+                && substationName1 == null
+                && substationName2 == null
+                && CollectionUtils.isEmpty(countries1)
+                && CollectionUtils.isEmpty(countries2)
+                && CollectionUtils.isEmpty(freeProperties1)
+                && CollectionUtils.isEmpty(freeProperties2);
+    }
+}

--- a/src/main/java/org/gridsuite/filter/server/dto/AbstractTransformerFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/AbstractTransformerFilter.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.filter.server.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.springframework.util.CollectionUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+@Schema(description = "Transformer Filters", allOf = CriteriaFilter.class)
+public abstract class AbstractTransformerFilter extends AbstractEquipmentFilterForm {
+
+    @Schema(description = "SubstationName")
+    private String substationName;
+
+    @Schema(description = "Countries")
+    private SortedSet<String> countries;
+
+    @Schema(description = "Free properties")
+    // LinkedHashMap to keep order too
+    @JsonDeserialize(as = LinkedHashMap.class)
+    private Map<String, List<String>> freeProperties;
+
+    AbstractTransformerFilter(String equipmentID, String equipmentName, String substationName, SortedSet<String> countries, Map<String, List<String>> freeProperties) {
+        super(equipmentID, equipmentName);
+        this.substationName = substationName;
+        this.countries = countries;
+        this.freeProperties = freeProperties;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty()
+                && substationName == null
+                && CollectionUtils.isEmpty(countries)
+                && CollectionUtils.isEmpty(freeProperties);
+    }
+}

--- a/src/main/java/org/gridsuite/filter/server/dto/HvdcLineFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/HvdcLineFilter.java
@@ -6,21 +6,15 @@
  */
 package org.gridsuite.filter.server.dto;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-
-import org.gridsuite.filter.server.utils.EquipmentType;
-import org.springframework.util.CollectionUtils;
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.gridsuite.filter.server.utils.EquipmentType;
+
+import java.util.SortedSet;
 
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
@@ -30,58 +24,26 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
-@Schema(description = "Hvdc Filters", allOf = AbstractEquipmentFilterForm.class)
-public class HvdcLineFilter extends AbstractEquipmentFilterForm {
+@Schema(description = "Hvdc Filters", allOf = AbstractLineFilter.class)
+public class HvdcLineFilter extends AbstractLineFilter {
     @Override
     public EquipmentType getEquipmentType() {
         return EquipmentType.HVDC_LINE;
     }
 
-    @Schema(description = "SubstationName1")
-    String substationName1;
-
-    @Schema(description = "SubstationName2")
-    String substationName2;
-
-    @Schema(description = "Countries1")
-    private SortedSet<String> countries1;
-
-    @Schema(description = "Countries2")
-    private SortedSet<String> countries2;
-
-    @Schema(description = "Free properties 1")
-    // LinkedHashMap to keep order too
-    @JsonDeserialize(as = LinkedHashMap.class)
-    private Map<String, List<String>> freeProperties1;
-
-    @Schema(description = "Free properties 2")
-    // LinkedHashMap to keep order too
-    @JsonDeserialize(as = LinkedHashMap.class)
-    private Map<String, List<String>> freeProperties2;
-
     @Schema(description = "Nominal voltage")
     private NumericalFilter nominalVoltage;
 
     public HvdcLineFilter(String equipmentID, String equipmentName, String substationName1, String substationName2,
-        SortedSet<String> countries1, SortedSet<String> countries2,
-        NumericalFilter nominalVoltage) {
-        super(equipmentID, equipmentName);
-        this.substationName1 = substationName1;
-        this.substationName2 = substationName2;
-        this.countries1 = countries1;
-        this.countries2 = countries2;
+                          SortedSet<String> countries1, SortedSet<String> countries2,
+                          NumericalFilter nominalVoltage) {
+        super(equipmentID, equipmentName, substationName1, substationName2, countries1, countries2);
         this.nominalVoltage = nominalVoltage;
     }
 
     @Override
     public boolean isEmpty() {
         return super.isEmpty()
-            && substationName1 == null
-            && substationName2 == null
-            && CollectionUtils.isEmpty(countries1)
-            && CollectionUtils.isEmpty(countries2)
-            && CollectionUtils.isEmpty(freeProperties1)
-            && CollectionUtils.isEmpty(freeProperties2)
-            && nominalVoltage == null;
+                && nominalVoltage == null;
     }
 }

--- a/src/main/java/org/gridsuite/filter/server/dto/LineFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/LineFilter.java
@@ -6,22 +6,10 @@
  */
 package org.gridsuite.filter.server.dto;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-
-import org.gridsuite.filter.server.utils.EquipmentType;
-import org.springframework.util.CollectionUtils;
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.gridsuite.filter.server.utils.EquipmentType;
 
 /**
  * @author Jacques Borsenberger <jacques.borsenberger at rte-france.com>
@@ -32,33 +20,11 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
-@Schema(description = "Line Filters", allOf = CriteriaFilter.class)
-public class LineFilter extends AbstractEquipmentFilterForm {
+@Schema(description = "Line Filters", allOf = AbstractLineFilter.class)
+public class LineFilter extends AbstractLineFilter {
     public EquipmentType getEquipmentType() {
         return EquipmentType.LINE;
     }
-
-    @Schema(description = "SubstationName1")
-    String substationName1;
-
-    @Schema(description = "SubstationName2")
-    String substationName2;
-
-    @Schema(description = "Countries1")
-    private SortedSet<String> countries1;
-
-    @Schema(description = "Countries2")
-    private SortedSet<String> countries2;
-
-    @Schema(description = "Free properties 1")
-    // LinkedHashMap to keep order too
-    @JsonDeserialize(as = LinkedHashMap.class)
-    private Map<String, List<String>> freeProperties1;
-
-    @Schema(description = "Free properties 2")
-    // LinkedHashMap to keep order too
-    @JsonDeserialize(as = LinkedHashMap.class)
-    private Map<String, List<String>> freeProperties2;
 
     @Schema(description = "Nominal voltage 1")
     private NumericalFilter nominalVoltage1;
@@ -69,13 +35,7 @@ public class LineFilter extends AbstractEquipmentFilterForm {
     @Override
     public boolean isEmpty() {
         return super.isEmpty()
-            && substationName1 == null
-            && substationName2 == null
-            && CollectionUtils.isEmpty(countries1)
-            && CollectionUtils.isEmpty(countries2)
-            && CollectionUtils.isEmpty(freeProperties1)
-            && CollectionUtils.isEmpty(freeProperties2)
-            && nominalVoltage1 == null
-            && nominalVoltage2 == null;
+                && nominalVoltage1 == null
+                && nominalVoltage2 == null;
     }
 }

--- a/src/main/java/org/gridsuite/filter/server/dto/LineFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/LineFilter.java
@@ -22,6 +22,7 @@ import org.gridsuite.filter.server.utils.EquipmentType;
 @ToString(callSuper = true)
 @Schema(description = "Line Filters", allOf = AbstractLineFilter.class)
 public class LineFilter extends AbstractLineFilter {
+    @Override
     public EquipmentType getEquipmentType() {
         return EquipmentType.LINE;
     }

--- a/src/main/java/org/gridsuite/filter/server/dto/ThreeWindingsTransformerFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/ThreeWindingsTransformerFilter.java
@@ -6,21 +6,13 @@
  */
 package org.gridsuite.filter.server.dto;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-
-import org.gridsuite.filter.server.utils.EquipmentType;
-import org.springframework.util.CollectionUtils;
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.gridsuite.filter.server.utils.EquipmentType;
 
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
@@ -30,23 +22,12 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
-@Schema(description = "Three windings transformer Filters", allOf = CriteriaFilter.class)
-public class ThreeWindingsTransformerFilter extends AbstractEquipmentFilterForm {
+@Schema(description = "Three windings transformer Filters", allOf = AbstractTransformerFilter.class)
+public class ThreeWindingsTransformerFilter extends AbstractTransformerFilter {
     @Override
     public EquipmentType getEquipmentType() {
         return EquipmentType.THREE_WINDINGS_TRANSFORMER;
     }
-
-    @Schema(description = "SubstationName")
-    String substationName;
-
-    @Schema(description = "Countries")
-    private SortedSet<String> countries;
-
-    @Schema(description = "Free properties")
-    // LinkedHashMap to keep order too
-    @JsonDeserialize(as = LinkedHashMap.class)
-    private Map<String, List<String>> freeProperties;
 
     @Schema(description = "Nominal voltage 1")
     private NumericalFilter nominalVoltage1;
@@ -60,11 +41,8 @@ public class ThreeWindingsTransformerFilter extends AbstractEquipmentFilterForm 
     @Override
     public boolean isEmpty() {
         return super.isEmpty()
-            && substationName == null
-            && CollectionUtils.isEmpty(countries)
-            && nominalVoltage1 == null
-            && nominalVoltage2 == null
-            && nominalVoltage3 == null
-            && CollectionUtils.isEmpty(freeProperties);
+                && nominalVoltage1 == null
+                && nominalVoltage2 == null
+                && nominalVoltage3 == null;
     }
 }

--- a/src/main/java/org/gridsuite/filter/server/dto/TwoWindingsTransformerFilter.java
+++ b/src/main/java/org/gridsuite/filter/server/dto/TwoWindingsTransformerFilter.java
@@ -6,21 +6,17 @@
  */
 package org.gridsuite.filter.server.dto;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-
-import org.gridsuite.filter.server.utils.EquipmentType;
-import org.springframework.util.CollectionUtils;
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.gridsuite.filter.server.utils.EquipmentType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
 
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
@@ -30,23 +26,12 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
-@Schema(description = "Two windings transformer Filters", allOf = CriteriaFilter.class)
-public class TwoWindingsTransformerFilter extends AbstractEquipmentFilterForm {
+@Schema(description = "Two windings transformer Filters", allOf = AbstractTransformerFilter.class)
+public class TwoWindingsTransformerFilter extends AbstractTransformerFilter {
     @Override
     public EquipmentType getEquipmentType() {
         return EquipmentType.TWO_WINDINGS_TRANSFORMER;
     }
-
-    @Schema(description = "SubstationName")
-    String substationName;
-
-    @Schema(description = "Countries")
-    private SortedSet<String> countries;
-
-    @Schema(description = "Free properties")
-    // LinkedHashMap to keep order too
-    @JsonDeserialize(as = LinkedHashMap.class)
-    private Map<String, List<String>> freeProperties;
 
     @Schema(description = "Nominal voltage 1")
     private NumericalFilter nominalVoltage1;
@@ -55,12 +40,9 @@ public class TwoWindingsTransformerFilter extends AbstractEquipmentFilterForm {
     private NumericalFilter nominalVoltage2;
 
     public TwoWindingsTransformerFilter(String equipmentID, String equipmentName, String substationName,
-        SortedSet<String> countries, Map<String, List<String>> freeProperties,
-        NumericalFilter nominalVoltage1, NumericalFilter nominalVoltage2) {
-        super(equipmentID, equipmentName);
-        this.substationName = substationName;
-        this.countries = countries;
-        this.freeProperties = freeProperties;
+                                        SortedSet<String> countries, Map<String, List<String>> freeProperties,
+                                        NumericalFilter nominalVoltage1, NumericalFilter nominalVoltage2) {
+        super(equipmentID, equipmentName, substationName, countries, freeProperties);
         this.nominalVoltage1 = nominalVoltage1;
         this.nominalVoltage2 = nominalVoltage2;
     }
@@ -68,10 +50,7 @@ public class TwoWindingsTransformerFilter extends AbstractEquipmentFilterForm {
     @Override
     public boolean isEmpty() {
         return super.isEmpty()
-            && substationName == null
-            && CollectionUtils.isEmpty(countries)
-            && nominalVoltage1 == null
-            && nominalVoltage2 == null
-            && CollectionUtils.isEmpty(freeProperties);
+                && nominalVoltage1 == null
+                && nominalVoltage2 == null;
     }
 }

--- a/src/test/java/org/gridsuite/filter/server/FilterEntityControllerTest.java
+++ b/src/test/java/org/gridsuite/filter/server/FilterEntityControllerTest.java
@@ -1539,4 +1539,38 @@ public class FilterEntityControllerTest {
                 [{"id":"LOAD","type":"LOAD"}]
                 """, EquipmentType.LOAD);
     }
+
+    @Test
+    public void lineFilterIsEmpty() throws Exception {
+        HvdcLineFilter hvdcFilter = new HvdcLineFilter(
+                "equipmentID",
+                "equipmentName",
+                "substationName1",
+                "substationName2",
+                COUNTRIES1,
+                COUNTRIES2,
+                new NumericalFilter(RangeType.RANGE, 50., null)
+        );
+        assertFalse(hvdcFilter.isEmpty());
+    }
+
+    @Test
+    public void transformerFilterIsEmpty() throws Exception {
+        LinkedHashSet<String> countries = new LinkedHashSet<>();
+        countries.add("FR");
+        countries.add("IT");
+
+        TwoWindingsTransformerFilter transformerFilter =
+                TwoWindingsTransformerFilter.builder()
+                        .equipmentID("2wtId1")
+                        .equipmentName("2wtName1")
+                        .substationName("s2")
+                        .countries(new TreeSet<>(countries))
+                        .freeProperties(Map.of("region", List.of("north")))
+                        .nominalVoltage1(NumericalFilter.builder().type(RangeType.RANGE).value1(370.).value2(390.).build())
+                        .nominalVoltage2(NumericalFilter.builder().type(RangeType.EQUALITY).value1(225.).build())
+                        .build();
+
+        assertFalse(transformerFilter.isEmpty());
+    }
 }

--- a/src/test/java/org/gridsuite/filter/server/FilterEntityControllerTest.java
+++ b/src/test/java/org/gridsuite/filter/server/FilterEntityControllerTest.java
@@ -1541,31 +1541,27 @@ public class FilterEntityControllerTest {
     }
 
     @Test
-    public void lineFilterIsEmpty() throws Exception {
+    public void lineFilterIsEmpty() {
         HvdcLineFilter hvdcFilter = new HvdcLineFilter(
                 "equipmentID",
                 "equipmentName",
                 "substationName1",
                 "substationName2",
-                COUNTRIES1,
-                COUNTRIES2,
+                new TreeSet<>(),
+                new TreeSet<>(),
                 new NumericalFilter(RangeType.RANGE, 50., null)
         );
         assertFalse(hvdcFilter.isEmpty());
     }
 
     @Test
-    public void transformerFilterIsEmpty() throws Exception {
-        LinkedHashSet<String> countries = new LinkedHashSet<>();
-        countries.add("FR");
-        countries.add("IT");
-
+    public void transformerFilterIsEmpty() {
         TwoWindingsTransformerFilter transformerFilter =
                 TwoWindingsTransformerFilter.builder()
                         .equipmentID("2wtId1")
                         .equipmentName("2wtName1")
                         .substationName("s2")
-                        .countries(new TreeSet<>(countries))
+                        .countries(new TreeSet<>())
                         .freeProperties(Map.of("region", List.of("north")))
                         .nominalVoltage1(NumericalFilter.builder().type(RangeType.RANGE).value1(370.).value2(390.).build())
                         .nominalVoltage2(NumericalFilter.builder().type(RangeType.EQUALITY).value1(225.).build())

--- a/src/test/java/org/gridsuite/filter/server/FilterEntityControllerTest.java
+++ b/src/test/java/org/gridsuite/filter/server/FilterEntityControllerTest.java
@@ -1543,10 +1543,10 @@ public class FilterEntityControllerTest {
     @Test
     public void lineFilterIsEmpty() {
         HvdcLineFilter hvdcFilter = new HvdcLineFilter(
-                "equipmentID",
-                "equipmentName",
-                "substationName1",
-                "substationName2",
+                null,
+                null,
+                null,
+                null,
                 new TreeSet<>(),
                 new TreeSet<>(),
                 new NumericalFilter(RangeType.RANGE, 50., null)
@@ -1558,9 +1558,9 @@ public class FilterEntityControllerTest {
     public void transformerFilterIsEmpty() {
         TwoWindingsTransformerFilter transformerFilter =
                 TwoWindingsTransformerFilter.builder()
-                        .equipmentID("2wtId1")
-                        .equipmentName("2wtName1")
-                        .substationName("s2")
+                        .equipmentID(null)
+                        .equipmentName(null)
+                        .substationName(null)
                         .countries(new TreeSet<>())
                         .freeProperties(Map.of("region", List.of("north")))
                         .nominalVoltage1(NumericalFilter.builder().type(RangeType.RANGE).value1(370.).value2(390.).build())


### PR DESCRIPTION
In order to be able to organize files by filter type (https://github.com/gridsuite/filter-server/pull/75). It reduces code duplication.