### PR TITLE
Override powsybl-ws-commons version to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
         <gridsuite-dependencies.version>34</gridsuite-dependencies.version>
         <string-template.version>4.3.1</string-template.version>
         <liquibase-hibernate-package>org.gridsuite.filter.server</liquibase-hibernate-package>
+        <!-- FIXME: powsybl-ws-commons version is overridden. To be removed at next gridsuite-dependencies.version upgrade -->
+        <powsybl-ws-commons.version>1.15.0</powsybl-ws-commons.version>
     </properties>
 
     <build>
@@ -84,6 +86,12 @@
     <dependencyManagement>
         <dependencies>
             <!-- overrides of imports -->
+            <!-- FIXME: powsybl-ws-commons version is overridden. To be removed at next gridsuite-dependencies.version upgrade -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-ws-commons</artifactId>
+                <version>${powsybl-ws-commons.version}</version>
+            </dependency>
 
             <!-- imports -->
             <dependency>

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -16,7 +16,3 @@ powsybl:
 powsybl-ws:
   database:
     name: filters
-
-server:
-  # TODO in the near future do we need spring 3.2 "server.tomcat.max-http-response-header-size" ?
-  max-http-request-header-size: 64000


### PR DESCRIPTION
- Override powsybl-ws-commons version to 1.15.0 which contains this fix: https://github.com/powsybl/powsybl-ws-commons/pull/74

- Delete "max-http-request-header-size: 64000" config because it exist already in powsybl-ws-commons config and there is no need to override it  : https://github.com/powsybl/powsybl-ws-commons/blob/1c549221f32648392f17ea6b19aa188a5882981e/src/main/resources/application.yaml#L12C1-L13C1.
